### PR TITLE
Add snapshot_url and make the data available to other plugins

### DIFF
--- a/octoprint_multicam/__init__.py
+++ b/octoprint_multicam/__init__.py
@@ -28,7 +28,7 @@ class MultiCamPlugin(octoprint.plugin.StartupPlugin,
             self._settings.set(['multicam_profiles'], self.get_settings_defaults()["multicam_profiles"])
 
     def get_settings_defaults(self):
-        return dict(multicam_profiles=[{'name':'Default','URL':octoprint.settings.settings().get(["webcam","stream"]), 'isButtonEnabled':'true'}])
+        return dict(multicam_profiles=[{'name':'Default', 'URL':octoprint.settings.settings().get(["webcam","stream"]), 'snapshot_url':octoprint.settings.settings().get(["webcam", "snapshot"]), 'isButtonEnabled':'true'}])
 
     def get_template_configs(self):
         return [
@@ -56,18 +56,35 @@ class MultiCamPlugin(octoprint.plugin.StartupPlugin,
                 pip="https://github.com/mikedmor/OctoPrint_MultiCam/archive/{target_version}.zip"
             )
         )
-
+    
+    ##~~ Exposed as helper
+    def get_webcams(self):
+        data = []
+        for index, profile in enumerate(self._settings.get(['multicam_profiles'])):
+            if index==0:
+                data.push({'name': 'Default', 'stream_url': self._settings.global_get(["webcam","stream"]), 'snapshot_url': self._settings.global_get(["webcam", "snapshot"])})
+            else:
+                data.push({'name': profile['name'], 'stream_url': profile['URL'], 'snapshot_url': profile['snapshot_url']})
+        return data
+    
+        
 __plugin_name__ = "MultiCam"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
+    plugin = MultiCamPlugin()
     global __plugin_implementation__
-    __plugin_implementation__ = MultiCamPlugin()
+    __plugin_implementation__ = plugin
 
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
     }
+    
+    global __plugin_helpers__
+    __plugin_helpers__ = dict(
+        get_webcams=plugin.get_webcams
+    )
 
 
 

--- a/octoprint_multicam/__init__.py
+++ b/octoprint_multicam/__init__.py
@@ -62,9 +62,9 @@ class MultiCamPlugin(octoprint.plugin.StartupPlugin,
         data = []
         for index, profile in enumerate(self._settings.get(['multicam_profiles'])):
             if index==0:
-                data.push({'name': 'Default', 'stream_url': self._settings.global_get(["webcam","stream"]), 'snapshot_url': self._settings.global_get(["webcam", "snapshot"])})
+                data.append({'name': 'Default', 'stream_url': self._settings.global_get(["webcam","stream"]), 'snapshot_url': self._settings.global_get(["webcam", "snapshot"])})
             else:
-                data.push({'name': profile['name'], 'stream_url': profile['URL'], 'snapshot_url': profile['snapshot_url']})
+                data.append({'name': profile['name'], 'stream_url': profile['URL'], 'snapshot_url': profile['snapshot_url']})
         return data
     
         

--- a/octoprint_multicam/static/js/multicam.js
+++ b/octoprint_multicam/static/js/multicam.js
@@ -30,7 +30,7 @@ $(function() {
         };
 
         self.addMultiCamProfile = function() {
-            self.settings.settings.plugins.multicam.multicam_profiles.push({name: ko.observable('Webcam '+self.multicam_profiles().length), URL: ko.observable('http://'), isButtonEnabled: ko.observable(true)});
+            self.settings.settings.plugins.multicam.multicam_profiles.push({name: ko.observable('Webcam '+self.multicam_profiles().length), URL: ko.observable('http://'), snapshot_url: ko.observable(''), isButtonEnabled: ko.observable(true)});
             self.multicam_profiles(self.settings.settings.plugins.multicam.multicam_profiles());
         };
 

--- a/octoprint_multicam/templates/multicam_settings.jinja2
+++ b/octoprint_multicam/templates/multicam_settings.jinja2
@@ -2,16 +2,20 @@
 <form id="settings_plugin_multicam_form" class="form-horizontal">
     <h3>{{ _('Multicam Profiles') }}</h3>
     <div class="row-fluid">
-        <div class="span5"><h4>{{ _('Name') }}</h4></div>
-        <div class="span5"><h4>{{ _('URL') }}</h4></div>
+        <div class="span2"><h4>{{ _('Name') }}</h4></div>
+        <div class="span4"><h4>{{ _('URL') }}</h4></div>
+        <div class="span4"><h4>{{ _('Snapshot URL') }}</h4></div>
     </div>
     <div data-bind="foreach: settings.settings.plugins.multicam.multicam_profiles">
         <div class="row-fluid" style="margin-bottom: 5px">
-            <div class="span5">
+            <div class="span2">
                 <input type="text" class="span12 text-right" data-bind="value: name">
             </div>
-            <div class="input-append span5">
+            <div class="input-append span4">
                 <input type="text" class="span12 text-right" data-bind="value: URL, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'URL of stream' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+            </div>
+            <div class="input-append span4">
+                <input type="text" class="span12 text-right" data-bind="value: snapshot_url, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Snapshot URL' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
             </div>
             <div class="span2">
                 <button title="Remove Webcam" class="btn btn-danger" data-bind="click: $parent.removeMultiCamProfile, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Remove Webcam' : 'Default Webcam cannot be removed!' }"><i class="fa fa-trash-o"></i></button>


### PR DESCRIPTION
Hi.

This pull requests does two things:
* It adds another field `snapshot_url` to each webcam.
* It makes the webcam settings available to other plugins via helper `get_webcams`.

The field `snapshot_url` isn't used by this plugin, but there are (at least one) other plugins using this value. But without it being available elsewhere, there are two possibilities:
* Try to construct it yourself ("take the stream URL, attach `?action=snapshot` and hope for the best")
* Have the user configure the webcam URLs, leading to having two places in the settings to configure if you change your webcam setup. 

Since pretty much every user using more than one webcam is going to use this plugin, I think it is the right place to have that setting as well.

Via the new helper `get_webcams`, other plugins can easily get that data without having to do other work such as falling back to reading the values from octoprint for the default webcam - the helper returns a "clean" array, with the data for the first webcam correctly filled out.