### PR TITLE
Added flip, rotation & ratio support

### DIFF
--- a/octoprint_multicam/__init__.py
+++ b/octoprint_multicam/__init__.py
@@ -19,7 +19,7 @@ class MultiCamPlugin(octoprint.plugin.StartupPlugin,
         self._logger.info("MultiCam Loaded! (more: %s)" % self._settings.get(["multicam_profiles"]))
 
     def get_settings_version(self):
-        return 1
+        return 2
 
     def on_settings_migrate(self, target, current=None):
         if current is None or current < self.get_settings_version():
@@ -28,7 +28,14 @@ class MultiCamPlugin(octoprint.plugin.StartupPlugin,
             self._settings.set(['multicam_profiles'], self.get_settings_defaults()["multicam_profiles"])
 
     def get_settings_defaults(self):
-        return dict(multicam_profiles=[{'name':'Default','URL':octoprint.settings.settings().get(["webcam","stream"]), 'isButtonEnabled':'true'}])
+        return dict(multicam_profiles=[{
+            'name':'Default',
+            'URL': octoprint.settings.settings().get(["webcam","stream"]),
+            'snapshot': octoprint.settings.settings().get(["webcam","snapshot"]),
+            'flipH':octoprint.settings.settings().get(["webcam","flipH"]),
+            'flipV':octoprint.settings.settings().get(["webcam","flipV"]),
+            'rotate90':octoprint.settings.settings().get(["webcam","rotate90"]),
+            'isButtonEnabled':'true'}])
 
     def get_template_configs(self):
         return [

--- a/octoprint_multicam/static/js/multicam.js
+++ b/octoprint_multicam/static/js/multicam.js
@@ -11,8 +11,6 @@ $(function() {
 
         self.enabled_buttons = ko.observableArray();
 
-        self.multicam_selected = ko.observable('');
-
         self.onBeforeBinding = function() {
             self.multicam_profiles(self.settings.settings.plugins.multicam.multicam_profiles());
         };

--- a/octoprint_multicam/static/js/multicam.js
+++ b/octoprint_multicam/static/js/multicam.js
@@ -14,9 +14,7 @@ $(function() {
         self.multicam_selected = ko.observable('');
 
         self.onBeforeBinding = function() {
-                console.log("Binding control to multicam");
-                camViewPort.attr("data-bind","css: { flipH: settings.plugins.multicam.multicam_profiles[].flipH}; attr: {url: }");
-                self.multicam_profiles(self.settings.settings.plugins.multicam.multicam_profiles());
+            self.multicam_profiles(self.settings.settings.plugins.multicam.multicam_profiles());
         };
 
         self.onSettingsShown = function() {

--- a/octoprint_multicam/static/js/multicam.js
+++ b/octoprint_multicam/static/js/multicam.js
@@ -15,14 +15,32 @@ $(function() {
         };
 
         self.onSettingsBeforeSave = function() {
-            ko.utils.arrayForEach(self.multicam_profiles(), function (item, index) {
-                if(index == 0 && item.URL != $('#settings-webcamStreamUrl').val()) {
-                    console.log("Changes Detected in Webcam & Timelaspse URL");
+            ko.utils.arrayForEach(self.settings.settings.plugins.multicam.multicam_profiles(), function (item, index) {
+                if(index == 0 && item.URL() != $('#settings-webcamStreamUrl').val()) {
+                    console.log("Changes Detected in Webcam settings : URL");
                     item.URL($('#settings-webcamStreamUrl').val());
                 }
+                if(index == 0 && item.snapshot() != $('#settings-webcamSnapshotUrl').val()) {
+                    console.log("Changes Detected in Webcam settings : Snapshot URL");
+                    item.snapshot($('#settings-webcamSnapshotUrl').val());
+                }
+                if(index == 0 && item.flipH() != $('#settings-webcamFlipH').is(':checked')) {
+                    console.log("Changes Detected in Webcam settings : FlipH");
+                    item.flipH($('#settings-webcamFlipH').is(':checked'));
+                }
+                if(index == 0 && item.flipV() != $('#settings-webcamFlipV').is(':checked')) {
+                    console.log("Changes Detected in Webcam settings : FlipV");
+                    item.flipV($('#settings-webcamFlipV').is(':checked'));
+                }
+                if(index == 0 && item.rotate90() != $('#settings-webcamRotate90').is(':checked')) {
+                    console.log("Changes Detected in Webcam settings : Rotate90");
+                    item.rotate90($('#settings-webcamRotate90').is(':checked'));
+                }
             });
-            self.settings.settings.plugins.multicam.multicam_profiles(self.multicam_profiles.slice(0));
-            self.onAfterTabChange();
+            console.log("Multicam_profiles:", self.multicam_profiles());
+            //self.settings.settings.plugins.multicam.multicam_profiles(self.multicam_profiles.slice(0));
+            //self.settings.settings.plugins.multicam.multicam_profiles(self.multicam_profiles());
+            //self.onAfterTabChange();
         };
 
         self.onEventSettingsUpdated = function(payload) {
@@ -30,7 +48,14 @@ $(function() {
         };
 
         self.addMultiCamProfile = function() {
-            self.settings.settings.plugins.multicam.multicam_profiles.push({name: ko.observable('Webcam '+self.multicam_profiles().length), URL: ko.observable('http://'), isButtonEnabled: ko.observable(true)});
+            self.settings.settings.plugins.multicam.multicam_profiles.push({
+                name: ko.observable('Webcam '+self.multicam_profiles().length), 
+                URL: ko.observable('http://'), 
+                snapshot: ko.observable('http://'), 
+                flipH: ko.observable(false),
+                flipV: ko.observable(false),
+                rotate90: ko.observable(false),
+                isButtonEnabled: ko.observable(true)});
             self.multicam_profiles(self.settings.settings.plugins.multicam.multicam_profiles());
         };
 
@@ -41,6 +66,15 @@ $(function() {
 
         self.loadWebcam = function(profile, event) {
             camViewPort.attr('src',ko.toJS(profile).URL);
+            if (ko.toJS(profile).flipH) { camViewPort.addClass('flipH'); } else { camViewPort.removeClass('flipH'); }
+            if (ko.toJS(profile).flipV) { camViewPort.addClass('flipV'); } else { camViewPort.removeClass('flipV'); }
+            if (ko.toJS(profile).rotate90) { 
+                $('#webcam_rotator').removeClass('webcam_unrotated');
+                $('#webcam_rotator').addClass('webcam_rotated');
+            } else {
+                $('#webcam_rotator').removeClass('webcam_rotated');
+                $('#webcam_rotator').addClass('webcam_unrotated');
+            }
             ko.utils.arrayForEach(self.multicam_profiles(), function (item) {
                 if(profile===item) {
                     item.isButtonEnabled(false);

--- a/octoprint_multicam/templates/multicam_settings.jinja2
+++ b/octoprint_multicam/templates/multicam_settings.jinja2
@@ -2,18 +2,36 @@
 <form id="settings_plugin_multicam_form" class="form-horizontal">
     <h3>{{ _('Multicam Profiles') }}</h3>
     <div class="row-fluid">
-        <div class="span5"><h4>{{ _('Name') }}</h4></div>
-        <div class="span5"><h4>{{ _('URL') }}</h4></div>
+        <div class="span4"><h4>{{ _('Name') }}</h4></div>
+        <div class="span4"><h4>{{ _('URL') }}</h4></div>
+        <!--<div class="span5"><h4>{{ _('Snapshot') }}</h4></div>-->
+        <div class="span1"><h4>{{ _('FlipH') }}</h4></div>
+        <div class="span1"><h4>{{ _('FlipV') }}</h4></div>
+        <div class="span1"><h4>{{ _('Rot90') }}</h4></div>
     </div>
     <div data-bind="foreach: settings.settings.plugins.multicam.multicam_profiles">
         <div class="row-fluid" style="margin-bottom: 5px">
-            <div class="span5">
+            <div class="span4">
                 <input type="text" class="span12 text-right" data-bind="value: name">
             </div>
-            <div class="input-append span5">
+            <div class="input-append span4">
                 <input type="text" class="span12 text-right" data-bind="value: URL, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'URL of stream' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
             </div>
-            <div class="span2">
+            <!--
+            <div class="input-append span4">
+                <input type="text" class="span12 text-right" data-bind="value: snapshot, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'URL of snapshot' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+            </div>
+            -->
+            <div class="span1">
+                <input type="checkbox" class="span12 text-right" data-bind="checked: flipH, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Flip Horizontally' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+            </div>
+            <div class="span1">
+                <input type="checkbox" class="span12 text-right" data-bind="checked: flipV, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Flip Vertically' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+            </div>
+            <div class="span1">
+                <input type="checkbox" class="span12 text-right" data-bind="checked: rotate90, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Rotate 90' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+            </div>
+            <div class="span1">
                 <button title="Remove Webcam" class="btn btn-danger" data-bind="click: $parent.removeMultiCamProfile, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Remove Webcam' : 'Default Webcam cannot be removed!' }"><i class="fa fa-trash-o"></i></button>
             </div>
         </div>

--- a/octoprint_multicam/templates/multicam_settings.jinja2
+++ b/octoprint_multicam/templates/multicam_settings.jinja2
@@ -2,16 +2,17 @@
 <form id="settings_plugin_multicam_form" class="form-horizontal">
     <h3>{{ _('Multicam Profiles') }}</h3>
     <div class="row-fluid">
-        <div class="span4"><h4>{{ _('Name') }}</h4></div>
-        <div class="span4"><h4>{{ _('URL') }}</h4></div>
+        <div class="span3 text-center"><h4>{{ _('Name') }}</h4></div>
+        <div class="span4 text-center"><h4>{{ _('URL') }}</h4></div>
         <!--<div class="span5"><h4>{{ _('Snapshot') }}</h4></div>-->
-        <div class="span1"><h4>{{ _('FlipH') }}</h4></div>
-        <div class="span1"><h4>{{ _('FlipV') }}</h4></div>
-        <div class="span1"><h4>{{ _('Rot90') }}</h4></div>
+        <div class="span1 text-center"><h4><i class="fa fa-arrows-alt fa-2x" title="{{ _('Stream aspect ratio') }}"></i></h4></div>
+        <div class="span1 text-center"><h4><i class="fa fa-arrows-h fa-2x" title="{{ _('Flip webcam horizontally') }}"></i></h4></div>
+        <div class="span1 text-center"><h4><i class="fa fa-arrows-v fa-2x" title="{{ _('Flip webcam vertically') }}"></i></h4></div>
+        <div class="span1 text-center"><h4><i class="fa fa-rotate-right fa-2x" title="{{ _('Rotate webcam 90 degrees counter clockwise') }}"></i></h4></div>
     </div>
     <div data-bind="foreach: settings.settings.plugins.multicam.multicam_profiles">
         <div class="row-fluid" style="margin-bottom: 5px">
-            <div class="span4">
+            <div class="span3">
                 <input type="text" class="span12 text-right" data-bind="value: name">
             </div>
             <div class="input-append span4">
@@ -23,13 +24,16 @@
             </div>
             -->
             <div class="span1">
-                <input type="checkbox" class="span12 text-right" data-bind="checked: flipH, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Flip Horizontally' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+                <select style="width: 100%" data-bind="options: $parent.settings.webcam_available_ratios, value: streamRatio, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Stream ratio' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }"></select>
             </div>
             <div class="span1">
-                <input type="checkbox" class="span12 text-right" data-bind="checked: flipV, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Flip Vertically' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+                <input style="padding: 4px; margin: 0px;" type="checkbox" class="span12 text-right" data-bind="checked: flipH, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Flip Horizontally' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
             </div>
             <div class="span1">
-                <input type="checkbox" class="span12 text-right" data-bind="checked: rotate90, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Rotate 90' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+                <input style="padding: 4px; margin: 0px;" type="checkbox" class="span12 text-right" data-bind="checked: flipV, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Flip Vertically' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
+            </div>
+            <div class="span1">
+                <input style="padding: 4px; margin: 0px;" type="checkbox" class="span12 text-right" data-bind="checked: rotate90, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Rotate 90' : 'Edit this field in the Webcam & Timelapse tab (Applies after Save)' }">
             </div>
             <div class="span1">
                 <button title="Remove Webcam" class="btn btn-danger" data-bind="click: $parent.removeMultiCamProfile, enable: $index()!==0, attr: { 'title': $index()!==0 ? 'Remove Webcam' : 'Default Webcam cannot be removed!' }"><i class="fa fa-trash-o"></i></button>


### PR DESCRIPTION
This PR adds support for options flipH, flipV, rotate90 and streamRatio available for default OctoPrint webcam to MultiCam. It is now possible to have different values for each webcam.
When migrating parameters, current webcam values will be taken for the newly added parameters.

Also extra little changes of how the plugin works: 
- it will internally change directly the settings of the webcam to the selected one. I made this change to fix the annoying bug when changing tab
- fixed a bug with saving parameters not working after multiple times 
- the snapshot URL is also handled, but not visible in the settings screen because of a lack of UI space :) (and I am not sure of the use of it)