### PR TITLE
Block installation on OctoPrint <1.9.0 instead of accidentally upgrading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ plugin_requires = []
 
 # Block installation on OctoPrint older than 1.9.0
 try:
-    from octoprint.util import is_octoprint_compatible
+    from octoprint.util.version import is_octoprint_compatible
     
     if not is_octoprint_compatible(">=1.9.0"):
         print("This plugin only works with OctoPrint 1.9.0 or newer - upgrade before installing it!")

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,19 @@ plugin_url = "https://github.com/mikedmor/OctoPrint_MultiCam"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["OctoPrint>=1.9.0"]
+plugin_requires = []
+
+# Block installation on OctoPrint older than 1.9.0
+try:
+    from octoprint.util import is_octoprint_compatible
+    
+    if not is_octoprint_compatible(">=1.9.0"):
+        print("This plugin only works with OctoPrint 1.9.0 or newer - upgrade before installing it!")
+        import sys
+        sys.exit(-1)
+except ImportError:
+    # OctoPrint is not installed, so installation will fail anyway
+    pass
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
Using `plugin_requires` will make this plugin upgrade OctoPrint alongside it, if someone on 1.8.x was to try and update the plugin. As much as we'd love to get everyone upgraded ASAP, you'll inevitably find someone that doesn't want to and gets grumpy, so we can save ourself from that. You will probably end up with the odd bug report from someone saying 'The installation is broken!1!1!' but they can be told they can't read instead.

The output is not *completely* obvious with the newer versions of pip in the last couple of years, but it does exist:

```
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting https://github.com/cp2004/OctoPrint_MultiCam/archive/refs/heads/patch-1.zip
  Downloading https://github.com/cp2004/OctoPrint_MultiCam/archive/refs/heads/patch-1.zip
     | 1.1 MB 5.5 MB/s 0:00:00
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 255
  ╰─> [1 lines of output]
      This plugin only works with OctoPrint 1.9.0 or newer - upgrade before installing it!
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```